### PR TITLE
do not transform ES6 modules for better tree shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,8 @@
             "not < 0.5%"
           ]
         },
-        "useBuiltIns": true
+        "useBuiltIns": true,
+        "modules": false
       }
     ]
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/babelrc",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/babelrc",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Contactlab Frontend Team official (extendible) Babel configuration",
   "main": ".babelrc",
   "scripts": {


### PR DESCRIPTION
In order to enhance tree shaking feature for tools like Webpack the ES6 modules syntax should not be transformed into Commonjs by Babel